### PR TITLE
feat: Unify Docker build with build.sh --docker

### DIFF
--- a/.github/workflows/bump-nginx.yml
+++ b/.github/workflows/bump-nginx.yml
@@ -63,31 +63,8 @@ jobs:
           echo "Detected build.sh version: $CURR"
           echo "current=$CURR" >> "$GITHUB_OUTPUT"
 
-      - name: Read current NGINX_VERSION from Dockerfile
-        id: current_dockerfile
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          test -f Dockerfile || { echo "Dockerfile not found" >&2; exit 1; }
-
-          CURR="$(
-            sed -nE 's/^[[:space:]]*ARG[[:space:]]+NGINX_VERSION=([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' Dockerfile \
-              | head -n1
-          )"
-
-          if [ -z "$CURR" ]; then
-            echo "Could not find ARG NGINX_VERSION in Dockerfile" >&2
-            exit 1
-          fi
-
-          echo "Detected Dockerfile version: $CURR"
-          echo "current=$CURR" >> "$GITHUB_OUTPUT"
-
-      - name: Update build.sh and Dockerfile if needed
-        if: |
-          steps.latest.outputs.latest != steps.current_build.outputs.current ||
-          steps.latest.outputs.latest != steps.current_dockerfile.outputs.current
+      - name: Update build.sh if needed
+        if: steps.latest.outputs.latest != steps.current_build.outputs.current
         shell: bash
         run: |
           set -euo pipefail
@@ -96,23 +73,16 @@ jobs:
             's|^([[:space:]]*readonly[[:space:]]+NGINX_VERSION[[:space:]]*=[[:space:]]*)"([0-9]+\.[0-9]+\.[0-9]+)"(.*)$|\1"${{ steps.latest.outputs.latest }}"\3|' \
             build.sh
 
-          sed -i -E \
-            's|^([[:space:]]*ARG[[:space:]]+NGINX_VERSION=)([0-9]+\.[0-9]+\.[0-9]+)(.*)$|\1${{ steps.latest.outputs.latest }}\3|' \
-            Dockerfile
-
           grep -nE '^[[:space:]]*readonly[[:space:]]+NGINX_VERSION[[:space:]]*=' build.sh
-          grep -nE '^[[:space:]]*ARG[[:space:]]+NGINX_VERSION=' Dockerfile
 
           curl -fsI --retry 3 --retry-all-errors \
             "https://nginx.org/download/nginx-${{ steps.latest.outputs.latest }}.tar.gz" > /dev/null
 
-          git diff -- build.sh Dockerfile
-          echo "Updated build.sh and Dockerfile to ${{ steps.latest.outputs.latest }}"
+          git diff -- build.sh
+          echo "Updated build.sh to ${{ steps.latest.outputs.latest }}"
 
       - name: Create pull request
-        if: |
-          steps.latest.outputs.latest != steps.current_build.outputs.current ||
-          steps.latest.outputs.latest != steps.current_dockerfile.outputs.current
+        if: steps.latest.outputs.latest != steps.current_build.outputs.current
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "[chore] Bump NGINX mainline from ${{ steps.current_build.outputs.current }} to ${{ steps.latest.outputs.latest }}"
@@ -121,13 +91,9 @@ jobs:
             Automated update for the latest NGINX mainline release.
 
             - Previous `build.sh` version: `${{ steps.current_build.outputs.current }}`
-            - Previous `Dockerfile` version: `${{ steps.current_dockerfile.outputs.current }}`
             - New version: `${{ steps.latest.outputs.latest }}`
 
-            This updates:
-
-            - `NGINX_VERSION` in `build.sh`
-            - `ARG NGINX_VERSION` in `Dockerfile`
+            This updates `NGINX_VERSION` in `build.sh`, which is used by both host and Docker builds.
 
             The workflow also verifies that the upstream NGINX tarball exists.
           branch: chore/bump-nginx-${{ steps.latest.outputs.latest }}
@@ -138,4 +104,3 @@ jobs:
             docker
           add-paths: |
             build.sh
-            Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
 # syntax=docker/dockerfile:1.7
 
 ARG DEBIAN_VERSION=trixie
-ARG NGINX_VERSION=1.31.2
-ARG NGINX_SIGNING_KEY_URL=https://nginx.org/keys/arut.key
-ARG NGINX_SIGNING_KEY_FINGERPRINT=43387825DDB1BB97EC36BA5D007C8D7C15D87369
 
 FROM debian:${DEBIAN_VERSION} AS builder
-
-ARG NGINX_VERSION
-ARG NGINX_SIGNING_KEY_URL
-ARG NGINX_SIGNING_KEY_FINGERPRINT
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -44,59 +37,7 @@ RUN test -f luna/modules/ngx_http_substitutions_filter_module/config \
  && test -f luna/modules/ngx_brotli/config \
  && test -f luna/modules/ngx_brotli/deps/brotli/c/include/brotli/encode.h
 
-# OpenSSL downloader populates luna/openssl-lts.
-RUN bash luna/openssl-downloader.sh
-
-RUN mkdir -p /src/luna/build \
- && cd /src/luna/build \
- && wget -O "nginx-${NGINX_VERSION}.tar.gz" "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" \
- && wget -O "nginx-${NGINX_VERSION}.tar.gz.asc" "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc" \
- && wget -O nginx-signing.key "${NGINX_SIGNING_KEY_URL}" \
- && export GNUPGHOME="$(mktemp -d)" \
- && chmod 700 "${GNUPGHOME}" \
- && gpg --batch --with-colons --import-options show-only --import nginx-signing.key > nginx-signing-key.txt \
- && actual_fingerprint="$(awk -F: '$1 == "fpr" { print $10; exit }' nginx-signing-key.txt)" \
- && test "${actual_fingerprint}" = "${NGINX_SIGNING_KEY_FINGERPRINT}" \
- && gpg --batch --import nginx-signing.key >/dev/null \
- && gpg --batch --status-fd 1 --verify "nginx-${NGINX_VERSION}.tar.gz.asc" "nginx-${NGINX_VERSION}.tar.gz" > nginx-verify-status.txt 2>/dev/null \
- && grep -q "^\[GNUPG:\] VALIDSIG ${NGINX_SIGNING_KEY_FINGERPRINT} " nginx-verify-status.txt \
- && rm -rf "${GNUPGHOME}" nginx-signing.key nginx-signing-key.txt nginx-verify-status.txt \
- && tar -xzf "nginx-${NGINX_VERSION}.tar.gz"
-
-WORKDIR /src/luna/build/nginx-${NGINX_VERSION}
-
-RUN bash /src/luna/branding-patch.sh
-
-RUN ./configure \
-    --prefix=/usr/share/nginx \
-    --sbin-path=/usr/sbin/nginx \
-    --conf-path=/etc/nginx/nginx.conf \
-    --pid-path=/var/run/nginx.pid \
-    --lock-path=/var/lock/nginx.lock \
-    --error-log-path=/var/log/nginx/error.log \
-    --http-log-path=/var/log/nginx/access.log \
-    --user=www-data \
-    --group=www-data \
-    --with-http_ssl_module \
-    --with-http_v2_module \
-    --with-http_v3_module \
-    --with-http_stub_status_module \
-    --with-http_gzip_static_module \
-    --with-http_sub_module \
-    --with-file-aio \
-    --with-threads \
-    --with-stream \
-    --with-stream_ssl_module \
-    --with-pcre \
-    --add-module=/src/luna/modules/ngx_http_substitutions_filter_module \
-    --add-module=/src/luna/modules/headers-more-nginx-module \
-    --add-module=/src/luna/modules/ngx_http_geoip2_module \
-    --add-module=/src/luna/modules/ngx_brotli \
-    --with-openssl=/src/luna/openssl-lts \
-    --with-openssl-opt=enable-ktls
-
-RUN make -j"$(nproc)" \
- && make install
+RUN bash ./build.sh --docker
 
 FROM debian:${DEBIAN_VERSION} AS runtime
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,15 @@ git submodule update --init --recursive
 ```
 
 Docker builds also expect the submodules to be initialized in the build context.
+The Dockerfile uses the same build script in Docker mode:
 
-The build script will:
+```bash
+./build.sh --docker
+```
+
+That mode performs the shared download, verification, patch, configure, build, and install flow without validating or restarting a host system service.
+
+In default host mode, the build script will:
 
 1. download and verify the pinned OpenSSL release,
 2. download the configured NGINX mainline version,

--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,8 @@ readonly NGINX_SIGNING_KEY_URL="https://nginx.org/keys/arut.key"
 readonly NGINX_SIGNING_KEY_FINGERPRINT="43387825DDB1BB97EC36BA5D007C8D7C15D87369"
 readonly SRC_DIR="${BUILD_DIR}/nginx-${NGINX_VERSION}"
 
+BUILD_MODE="host"
+
 LIGHTBLUE=$'\033[1;34m'
 GREEN=$'\033[0;32m'
 YELLOW=$'\033[1;33m'
@@ -38,6 +40,16 @@ warn() {
 die() {
     printf '%b\n' "${RED}Error: $*${NC}" >&2
     exit 1
+}
+
+usage() {
+    cat <<EOF
+Usage: $0 [--host|--docker]
+
+Modes:
+  --host    Build, install, validate, and restart the Luna-HTTP/S service.
+  --docker  Build and install only; intended for Docker builder stages.
+EOF
 }
 
 cleanup_on_error() {
@@ -62,19 +74,43 @@ ensure_dir() {
 
 print_banner() {
     printf '%b\n' "*******************************************************
-          ${PURPLE}Tiekoetter.net Luna-HTTP/S Builder v2${NC}
+              ${PURPLE}Luna-HTTP/S Builder${NC}
 
- Working with NGINX Version \"${NGINX_VERSION}\"
- OpenSSL with TLS 1.3 Support + kTLS
- HTTP3 / QUIC (experimental)
+ Project:        Luna-HTTP/S
+ Mode:           ${BUILD_MODE}
+ Upstream:       NGINX ${NGINX_VERSION}
+ TLS stack:      OpenSSL LTS with TLS 1.3 and kTLS
+ Protocols:      HTTP/1.1, HTTP/2, HTTP/3 / QUIC
 
- ngx_brotli
- ngx_http_geoip2_module
- headers-more-nginx-module
- ngx_http_substitutions_filter_module
+ Built-in modules:
+   - ngx_brotli
+   - ngx_http_geoip2_module
+   - headers-more-nginx-module
+   - ngx_http_substitutions_filter_module
 
  Copyright © 2018-2026 Léon Tiekötter <leon@tiekoetter.com>
 *******************************************************"
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --host)
+                BUILD_MODE="host"
+                ;;
+            --docker)
+                BUILD_MODE="docker"
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                die "Unknown argument: $1"
+                ;;
+        esac
+        shift
+    done
 }
 
 check_environment() {
@@ -85,10 +121,13 @@ check_environment() {
     require_command awk
     require_command tar
     require_command make
-    require_command systemctl
     require_command nproc
     require_command bash
     require_command perl
+
+    if [[ "${BUILD_MODE}" == "host" ]]; then
+        require_command systemctl
+    fi
 
     ensure_dir "${LUNA_DIR}"
     ensure_dir "${OPENSSL_DIR}"
@@ -107,22 +146,23 @@ check_environment() {
     require_file "${MODULES_DIR}/headers-more-nginx-module/config"
     require_file "${MODULES_DIR}/ngx_http_geoip2_module/config"
     require_file "${MODULES_DIR}/ngx_brotli/config"
+    require_file "${MODULES_DIR}/ngx_brotli/deps/brotli/c/include/brotli/encode.h"
 }
 
 download_openssl() {
-    log "Starting OpenSSL downloader..."
+    log "Preparing Luna-HTTP/S OpenSSL source..."
     cd "${LUNA_DIR}"
     bash "./openssl-downloader.sh"
 }
 
 prepare_build_dir() {
-    log "Preparing clean build directory..."
+    log "Preparing clean Luna-HTTP/S build directory..."
     rm -rf "${BUILD_DIR}"
     mkdir -p "${BUILD_DIR}"
 }
 
-verify_nginx_signature() {
-    log "Verifying NGINX release signature..."
+verify_upstream_signature() {
+    log "Verifying upstream NGINX release signature..."
 
     local key_file="${BUILD_DIR}/nginx-signing.key"
     local key_metadata="${BUILD_DIR}/nginx-signing-key.txt"
@@ -139,31 +179,31 @@ verify_nginx_signature() {
 
     actual_fingerprint="$(awk -F: '$1 == "fpr" { print $10; exit }' "${key_metadata}")"
     [[ "${actual_fingerprint}" == "${NGINX_SIGNING_KEY_FINGERPRINT}" ]] || \
-        die "Unexpected NGINX signing key fingerprint: ${actual_fingerprint}"
+        die "Unexpected upstream NGINX signing key fingerprint: ${actual_fingerprint}"
 
     GNUPGHOME="${gnupg_home}" gpg --batch --import "${key_file}" >/dev/null
     if ! verify_status="$(GNUPGHOME="${gnupg_home}" gpg --batch --status-fd 1 --verify "${BUILD_DIR}/${NGINX_SIGNATURE}" "${BUILD_DIR}/${NGINX_TARBALL}" 2>/dev/null)"; then
-        die "NGINX release signature verification failed."
+        die "Upstream NGINX release signature verification failed."
     fi
 
     grep -q "^\[GNUPG:\] VALIDSIG ${NGINX_SIGNING_KEY_FINGERPRINT} " <<< "${verify_status}" || \
-        die "NGINX release signature was not made by the pinned key."
+        die "Upstream NGINX release signature was not made by the pinned key."
 
     rm -rf "${gnupg_home}" "${key_file}" "${key_metadata}"
 }
 
-download_nginx() {
-    log "Downloading NGINX ${NGINX_VERSION}..."
+download_upstream_nginx() {
+    log "Downloading upstream NGINX ${NGINX_VERSION}..."
     cd "${BUILD_DIR}"
     wget -O "${NGINX_TARBALL}" "${NGINX_URL}"
     wget -O "${NGINX_SIGNATURE}" "${NGINX_SIGNATURE_URL}"
-    verify_nginx_signature
+    verify_upstream_signature
     tar -xzf "${NGINX_TARBALL}"
     [[ -d "${SRC_DIR}" ]] || die "Extracted source directory not found: ${SRC_DIR}"
 }
 
-patch_nginx() {
-    log "Applying Luna-HTTP/S branding patch..."
+apply_luna_patches() {
+    log "Applying Luna-HTTP/S source patches..."
     cd "${SRC_DIR}"
     bash "${BRANDING_PATCH_SCRIPT}"
 
@@ -172,11 +212,11 @@ patch_nginx() {
         "src/http/ngx_http_special_response.c" \
         "src/http/v2/ngx_http_v2_filter_module.c" \
         "src/http/v3/ngx_http_v3_filter_module.c" >/dev/null || \
-        die "Luna branding patch did not apply correctly."
+        die "Luna-HTTP/S branding patch did not apply correctly."
 }
 
-configure_nginx() {
-    log "Configuring Luna-HTTP/S..."
+configure_luna() {
+    log "Configuring Luna-HTTP/S build..."
     cd "${SRC_DIR}"
 
     ./configure \
@@ -208,43 +248,52 @@ configure_nginx() {
         --with-openssl-opt=enable-ktls
 }
 
-build_nginx() {
+build_luna() {
     log "Building Luna-HTTP/S..."
     cd "${SRC_DIR}"
     make -j"$(nproc)"
 }
 
-install_nginx() {
+install_luna() {
     log "Installing Luna-HTTP/S..."
     cd "${SRC_DIR}"
     make install
 }
 
-validate_nginx() {
-    log "Validating installed NGINX configuration..."
+validate_luna() {
+    log "Validating installed Luna-HTTP/S configuration..."
     /usr/sbin/nginx -t
 }
 
-restart_nginx() {
-    log "Restarting NGINX..."
+restart_luna() {
+    log "Restarting Luna-HTTP/S service..."
     systemctl restart nginx
-    systemctl --no-pager --full status nginx || die "NGINX restart failed."
+    systemctl --no-pager --full status nginx || die "Luna-HTTP/S service restart failed."
 }
 
 main() {
+    parse_args "$@"
+
     print_banner
     check_environment
     download_openssl
     prepare_build_dir
-    download_nginx
-    patch_nginx
-    configure_nginx
-    build_nginx
-    install_nginx
-    validate_nginx
-    restart_nginx
+    download_upstream_nginx
+    apply_luna_patches
+    configure_luna
+    build_luna
+    install_luna
 
-    printf '\n%b\n' "${GREEN}Done.${NC} Luna-HTTP/S is now active and online!"
+    if [[ "${BUILD_MODE}" == "host" ]]; then
+        validate_luna
+        restart_luna
+    fi
+
+    if [[ "${BUILD_MODE}" == "docker" ]]; then
+        printf '\n%b\n' "${GREEN}Done.${NC} Luna-HTTP/S is built and installed for the container image."
+    else
+        printf '\n%b\n' "${GREEN}Done.${NC} Luna-HTTP/S is now active and online!"
+    fi
 }
 
 main "$@"

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,7 @@ IFS=$'\n\t'
 readonly NGINX_VERSION="1.31.2"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
-readonly PROJECT_ROOT="${SCRIPT_DIR}"
-readonly LUNA_DIR="${PROJECT_ROOT}/luna"
+readonly LUNA_DIR="${SCRIPT_DIR}/luna"
 readonly BRANDING_PATCH_SCRIPT="${LUNA_DIR}/branding-patch.sh"
 readonly OPENSSL_DIR="${LUNA_DIR}/openssl-lts"
 readonly MODULES_DIR="${LUNA_DIR}/modules"
@@ -24,17 +23,12 @@ BUILD_MODE="host"
 
 LIGHTBLUE=$'\033[1;34m'
 GREEN=$'\033[0;32m'
-YELLOW=$'\033[1;33m'
 RED=$'\033[0;31m'
 PURPLE=$'\033[0;35m'
 NC=$'\033[0m'
 
 log() {
     printf '%b\n' "${LIGHTBLUE}$*${NC}"
-}
-
-warn() {
-    printf '%b\n' "${YELLOW}Warning: $*${NC}" >&2
 }
 
 die() {
@@ -66,10 +60,6 @@ require_command() {
 
 require_file() {
     [[ -f "$1" ]] || die "Required file not found: $1"
-}
-
-ensure_dir() {
-    mkdir -p "$1"
 }
 
 print_banner() {
@@ -122,22 +112,11 @@ check_environment() {
     require_command tar
     require_command make
     require_command nproc
-    require_command bash
     require_command perl
 
     if [[ "${BUILD_MODE}" == "host" ]]; then
         require_command systemctl
     fi
-
-    ensure_dir "${LUNA_DIR}"
-    ensure_dir "${OPENSSL_DIR}"
-    ensure_dir "${MODULES_DIR}"
-    ensure_dir "${BUILD_ROOT}"
-
-    ensure_dir "${MODULES_DIR}/ngx_http_substitutions_filter_module"
-    ensure_dir "${MODULES_DIR}/headers-more-nginx-module"
-    ensure_dir "${MODULES_DIR}/ngx_http_geoip2_module"
-    ensure_dir "${MODULES_DIR}/ngx_brotli"
 
     require_file "${LUNA_DIR}/openssl-downloader.sh"
     require_file "${LUNA_DIR}/openssl-version.env"
@@ -152,7 +131,7 @@ check_environment() {
 download_openssl() {
     log "Preparing Luna-HTTP/S OpenSSL source..."
     cd "${LUNA_DIR}"
-    bash "./openssl-downloader.sh"
+    "${BASH}" "./openssl-downloader.sh"
 }
 
 prepare_build_dir() {
@@ -205,7 +184,7 @@ download_upstream_nginx() {
 apply_luna_patches() {
     log "Applying Luna-HTTP/S source patches..."
     cd "${SRC_DIR}"
-    bash "${BRANDING_PATCH_SCRIPT}"
+    "${BASH}" "${BRANDING_PATCH_SCRIPT}"
 
     grep -RIn 'luna-http/s\|Luna-HTTP/S' \
         "src/http/ngx_http_header_filter_module.c" \


### PR DESCRIPTION
Delegate Docker-stage builds to build.sh --docker and centralize NGINX version handling in the script. Dockerfile no longer contains ARG NGINX_VERSION or the in-Dockerfile download/verify/build steps; it now runs `bash ./build.sh --docker` in the builder stage. build.sh was refactored: added BUILD_MODE (host|docker), CLI parsing, usage message, renamed/refactored functions (download/verify/patch/configure/build/install/validate/restart -> download_upstream_nginx, verify_upstream_signature, apply_luna_patches, configure_luna, build_luna, install_luna, validate_luna, restart_luna), and made systemctl a host-only requirement so Docker builds skip service validation/restart. README updated to document the Docker mode. The GitHub Actions workflow was simplified to only bump build.sh (removing Dockerfile parsing/updates) and PR text adjusted accordingly.