### PR TITLE
feat: Enable NGINX realip module in Luna build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN bash ./build.sh --docker
 FROM debian:${DEBIAN_VERSION} AS runtime
 
 LABEL org.opencontainers.image.title="Luna-HTTP/S"
-LABEL org.opencontainers.image.description="Custom NGINX build with OpenSSL LTS, HTTP/3, Brotli, GeoIP2, headers-more and substitutions filter"
+LABEL org.opencontainers.image.description="Custom NGINX build with OpenSSL LTS, HTTP/3, Brotli, real IP, GeoIP2, headers-more and substitutions filter"
 LABEL org.opencontainers.image.url="https://lunahttps.tiekoetter.net"
 LABEL org.opencontainers.image.source="https://github.com/tiekoetter/lunahttps"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Custom-built NGINX with enhanced performance, modern protocol support, Docker image builds, and security-focused features.
 
-Luna-HTTP/S is based on NGINX mainline and adds a curated build configuration with OpenSSL 3.5.x, TLS 1.3, post-quantum cryptography support, HTTP/2, HTTP/3 / QUIC, Brotli, GeoIP2, advanced header manipulation, and response body substitution support.
+Luna-HTTP/S is based on NGINX mainline and adds a curated build configuration with OpenSSL 3.5.x, TLS 1.3, post-quantum cryptography support, HTTP/2, HTTP/3 / QUIC, Brotli, real client IP handling, GeoIP2, advanced header manipulation, and response body substitution support.
 
 Project information is available at [lunahttps.tiekoetter.net](https://lunahttps.tiekoetter.net).
 
@@ -16,6 +16,7 @@ Project information is available at [lunahttps.tiekoetter.net](https://lunahttps
 - **HTTP/2 support**
 - **HTTP/3 / QUIC support** for reduced latency and faster connections
 - **Brotli compression** for reduced bandwidth usage and faster page loads
+- **ngx_http_realip_module** for preserving trusted proxy client addresses
 - **ngx_http_geoip2_module** for GeoIP-based request handling
 - **headers-more-nginx-module** for advanced header control
 - **ngx_http_substitutions_filter_module** for RegEx-based response body filtering and substitution
@@ -30,6 +31,7 @@ This build is tailored for high-performance environments and is compiled with ad
 
 **Included modules:**
 
+- [ngx_http_realip_module](https://nginx.org/en/docs/http/ngx_http_realip_module.html)
 - [ngx_brotli](https://github.com/google/ngx_brotli)
 - [ngx_http_geoip2_module](https://github.com/leev/ngx_http_geoip2_module)
 - [headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module)

--- a/build.sh
+++ b/build.sh
@@ -74,6 +74,7 @@ print_banner() {
 
  Built-in modules:
    - ngx_brotli
+   - ngx_http_realip_module
    - ngx_http_geoip2_module
    - headers-more-nginx-module
    - ngx_http_substitutions_filter_module
@@ -211,6 +212,7 @@ configure_luna() {
         --with-http_ssl_module \
         --with-http_v2_module \
         --with-http_v3_module \
+        --with-http_realip_module \
         --with-http_stub_status_module \
         --with-http_gzip_static_module \
         --with-http_sub_module \


### PR DESCRIPTION
Adds `--with-http_realip_module` to the NGINX configure flags so Luna-HTTP/S can preserve trusted proxy client IP addresses. Updates the build banner, README feature/module lists, and Docker image description to reflect real IP support.